### PR TITLE
fix: should resolve paths exactly the same as input path with trailing slash

### DIFF
--- a/src/__tests__/try-path.test.ts
+++ b/src/__tests__/try-path.test.ts
@@ -257,4 +257,35 @@ describe("mapping-entry", () => {
       },
     ]);
   });
+
+  it("glob match with suffix part on result", () => {
+    const result = getPathsToTry(
+      [],
+      [
+        {
+          pattern: "/opt/*",
+          paths: [join("/absolute", "src", "*", "suffix", "part")],
+        },
+      ],
+      "/opt/relative/part"
+    );
+    expect(result).toEqual([
+      {
+        path: join("/absolute", "src", "relative", "part", "suffix", "part"),
+        type: "file",
+      },
+      {
+        path: join(
+          "/absolute",
+          "src",
+          "relative",
+          "part",
+          "suffix",
+          "part",
+          "package.json"
+        ),
+        type: "package",
+      },
+    ]);
+  });
 });

--- a/src/__tests__/try-path.test.ts
+++ b/src/__tests__/try-path.test.ts
@@ -234,4 +234,27 @@ describe("mapping-entry", () => {
       },
     ]);
   });
+
+  it("should resolve paths exactly same as input path without trailing slash", () => {
+    const result = getPathsToTry(
+      [],
+      [
+        {
+          pattern: "/opt/*",
+          paths: [join("/absolute", "src", "*")],
+        },
+      ],
+      "/opt"
+    );
+    expect(result).toEqual([
+      {
+        path: join("/absolute", "src") + "/",
+        type: "file",
+      },
+      {
+        path: join("/absolute", "src", "package.json"),
+        type: "package",
+      },
+    ]);
+  });
 });

--- a/src/__tests__/try-path.test.ts
+++ b/src/__tests__/try-path.test.ts
@@ -211,4 +211,27 @@ describe("mapping-entry", () => {
       },
     ]);
   });
+
+  it("should resolve paths exactly same as input path with trailing slash", () => {
+    const result = getPathsToTry(
+      [],
+      [
+        {
+          pattern: "/opt/*",
+          paths: [join("/absolute", "src", "*")],
+        },
+      ],
+      "/opt/"
+    );
+    expect(result).toEqual([
+      {
+        path: join("/absolute", "src") + "/",
+        type: "file",
+      },
+      {
+        path: join("/absolute", "src", "package.json"),
+        type: "package",
+      },
+    ]);
+  });
 });

--- a/src/try-path.ts
+++ b/src/try-path.ts
@@ -93,7 +93,7 @@ export function exhaustiveTypeException(check: never): never {
  * @returns the part of search that * matches, or undefined if no match.
  */
 function matchStar(pattern: string, search: string): string | undefined {
-  if (search.length < pattern.length) {
+  if (search.length + 1 < pattern.length) {
     return undefined;
   }
   if (pattern === "*") {

--- a/src/try-path.ts
+++ b/src/try-path.ts
@@ -93,7 +93,7 @@ export function exhaustiveTypeException(check: never): never {
  * @returns the part of search that * matches, or undefined if no match.
  */
 function matchStar(pattern: string, search: string): string | undefined {
-  if (search.length + 1 < pattern.length) {
+  if (search.length + 2 < pattern.length) {
     return undefined;
   }
   if (pattern === "*") {
@@ -105,6 +105,10 @@ function matchStar(pattern: string, search: string): string | undefined {
   }
   const part1 = pattern.substring(0, star);
   const part2 = pattern.substring(star + 1);
+  // "/some/path/*" should match "/some/path"
+  if (part1 === search + "/" && part2 === "") {
+    return "";
+  }
   if (search.substr(0, star) !== part1) {
     return undefined;
   }


### PR DESCRIPTION
Fix #280 